### PR TITLE
Informative error for un-`dev`ved packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,9 @@ version = "0.1.0"
 julia = "1.3"
 
 [extras]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Example", "Pkg", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,8 +36,8 @@ using Test
     @test occursin("- `Main.anonymous.foo3`: `foo3` contains a [`Main.anonymous.foo1`](@ref) that contains a period.", str)
 
     if Base.VERSION >= v"1.8.0-DEV.363"   # use strings in @test_throws; we don't care what type of error this is
-        @test_throws "must be a package that you have checked out in" ModuleDocstrings.write(m)
-        @test_throws "must be a package that you have checked out in" ModuleDocstrings.write(Example)
+        @test_throws "must be a writable package, but there is no corresponding file" ModuleDocstrings.write(m)
+        @test_throws r"must be a writable package, but the path \".*\" is not writable" ModuleDocstrings.write(Example)
     else
         @test_throws Exception ModuleDocstrings.write(m)
         @test_throws Exception ModuleDocstrings.write(Example)


### PR DESCRIPTION
Modules defined at the REPL or packages being used in `add` mode
are not amenable to updates. Rather than throw a cryptic error
it's better to suggest the solution.

An alternative would be to register an error hint, but that wouldn't work on older Julia versions. Thoughts? The one advantage I can think of is that the complete form of the original error is retained, just in case the suggested solution is wrong.